### PR TITLE
Fix loading configured plugins

### DIFF
--- a/lib/Template/Alloy/Play.pm
+++ b/lib/Template/Alloy/Play.pm
@@ -825,7 +825,7 @@ sub play_USE {
 
     } elsif (my $pkg = $self->{'PLUGINS'}->{$module} || $self->{'PLUGINS'}->{lc $module}) {
         (my $req = "$pkg.pm") =~ s|::|/|g;
-        if (UNIVERSAL::isa($pkg, 'UNIVERSAL') || eval { require $req }) {
+        if (eval { require $req }) {
             my $shape = $pkg->load;
             $obj = $shape->new($self->context, $foreign ? @$foreign : map { $self->play_expr($_) } @args);
         }

--- a/t/35_plugins.t
+++ b/t/35_plugins.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+
+use Template::Alloy;
+use Test::More tests => 2;
+
+my $t = Template::Alloy->new;
+
+$t->process(\'[% USE foo %]');
+
+is $t->error, 'plugin error - foo: plugin not found';
+
+$t->{PLUGINS}{foo} = 'foo';
+
+$t->process(\'[% USE foo %]');
+
+is $t->error, 'plugin error - foo: plugin not found';


### PR DESCRIPTION
Under newer perls, UNIVERSAL::isa(..., 'UNIVERSAL') always returns
true:

$ perl -E 'say UNIVERSAL::isa("foo", "UNIVERSAL")'
1

So instead just try to require the package on every USE line, it'll
short-circuit if it's already loaded up.